### PR TITLE
Fix missing PDF in releases

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -24,6 +24,9 @@ jobs:
     - name: Create output directory
       run: mkdir -p build
 
+    - name: Install DejaVu fonts for PDF generation
+      run: apk add --no-cache font-dejavu
+
     - name: Create dummy styles.css (if not present)
       run: |
         mkdir -p tools

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -28,6 +28,9 @@ jobs:
     - name: Create output directory
       run: mkdir -p build
 
+    - name: Install DejaVu fonts for PDF generation
+      run: apk add --no-cache font-dejavu
+
     - name: Create dummy styles.css (if not present)
       run: |
         mkdir -p tools

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 
 BUILD_DIR="build"
 GH_PAGES_BUILD_DIR="$BUILD_DIR/gh-pages-site"

--- a/website/templates/header-en.html
+++ b/website/templates/header-en.html
@@ -7,6 +7,7 @@
             <li class="dropdown">
                 <a href="https://github.com/vredchenko/konspekt-istorii-ukrainy-braichevsky/releases" class="dropdown-trigger">Download &#9662;</a>
                 <ul class="dropdown-menu">
+                    <li><a href="https://github.com/vredchenko/konspekt-istorii-ukrainy-braichevsky/releases/latest/download/konspekt-istorii-ukrainy-braichevsky-en.pdf">PDF</a></li>
                     <li><a href="https://github.com/vredchenko/konspekt-istorii-ukrainy-braichevsky/releases/latest/download/konspekt-istorii-ukrainy-braichevsky-en.epub">EPUB</a></li>
                     <li><a href="https://github.com/vredchenko/konspekt-istorii-ukrainy-braichevsky/releases/latest/download/konspekt-istorii-ukrainy-braichevsky-en.docx">DOCX</a></li>
                     <li><a href="https://github.com/vredchenko/konspekt-istorii-ukrainy-braichevsky/releases/latest/download/konspekt-istorii-ukrainy-braichevsky-en.html">HTML</a></li>

--- a/website/templates/header-ua.html
+++ b/website/templates/header-ua.html
@@ -7,6 +7,7 @@
             <li class="dropdown">
                 <a href="https://github.com/vredchenko/konspekt-istorii-ukrainy-braichevsky/releases" class="dropdown-trigger">Завантажити &#9662;</a>
                 <ul class="dropdown-menu">
+                    <li><a href="https://github.com/vredchenko/konspekt-istorii-ukrainy-braichevsky/releases/latest/download/konspekt-istorii-ukrainy-braichevsky.pdf">PDF</a></li>
                     <li><a href="https://github.com/vredchenko/konspekt-istorii-ukrainy-braichevsky/releases/latest/download/konspekt-istorii-ukrainy-braichevsky.epub">EPUB</a></li>
                     <li><a href="https://github.com/vredchenko/konspekt-istorii-ukrainy-braichevsky/releases/latest/download/konspekt-istorii-ukrainy-braichevsky.docx">DOCX</a></li>
                     <li><a href="https://github.com/vredchenko/konspekt-istorii-ukrainy-braichevsky/releases/latest/download/konspekt-istorii-ukrainy-braichevsky.html">HTML</a></li>


### PR DESCRIPTION
## Summary
- Added `set -e` to `build.sh` so build failures are caught instead of silently ignored
- Install DejaVu fonts (`apk add font-dejavu`) in both CI workflows (`publish-release.yml` and `build-pr.yml`) so xelatex PDF generation succeeds in the `pandoc/latex` Alpine container
- Added PDF download links to the GitHub Pages header dropdowns (UA and EN)

Fixes #9

## Test plan
- [x] Verify PR build CI passes (check artifacts for `book.pdf` and `book-en.pdf`)
- [x] Review generated PDFs locally for quality
- [ ] After merge, tag `v0.2.2` and confirm release includes `.pdf` assets

🤖 Generated with [Claude Code](https://claude.com/claude-code)